### PR TITLE
:put_litter_in_its_place: Remove omnisharp-vim Vundle

### DIFF
--- a/dotfiles/.vimrc
+++ b/dotfiles/.vimrc
@@ -25,7 +25,7 @@ Plugin 'vim-airline/vim-airline'          " File status bar
 Plugin 'lepture/vim-jinja'                " Jinja/Nunjucks highlighting
 Plugin 'junegunn/vim-easy-align'          " Better/easier alignment
 Plugin 'fatih/vim-go'                     " Better/easier alignment
-Plugin 'OmniSharp/omnisharp-vim'          " Provides IDE like abilities for C#
+" Plugin 'OmniSharp/omnisharp-vim'          " Provides IDE like abilities for C#
 " Plugin 'Townk/vim-autoclose' " Auto pair/close - Disabled as it kept
 " putting Vim into insert mode when there was a thing to auto complete
 " Plugin 'jiangmiao/auto-pairs'             " Auto pair/close


### PR DESCRIPTION
It is causing errors and isn't used.