### PR TITLE
:black_circle: Install ngrok

### DIFF
--- a/brewcask.sh
+++ b/brewcask.sh
@@ -34,6 +34,7 @@ microsoft-azure-storage-explorer
 microsoft-office
 minikube
 mono-mdk
+ngrok
 owasp-zap
 postman
 powershell


### PR DESCRIPTION
As per the instructions on https://dashboard.ngrok.com/get-started, run
`ngrok authtoken <authtoken>` to complete setup.
The application probably will not run without allowing it by clicking on
`Allow anyway` from `System Prefs -> Security & Privacy -> General`.